### PR TITLE
added minimum lot area for Residential

### DIFF
--- a/zones/index.html
+++ b/zones/index.html
@@ -80,7 +80,8 @@ title: Zoning districts
           <th></th>
           <th>Name</th>
           <th data-content="A building's total floor area - that is, the square footage of every floor - divided by the area of the parcel of land it's built on. Controls a property's density." data-original-title='Floor area ratio' data-placement='top' rel='popover'>Floor area ratio</th>
-          <th data-content="The amount of lot area required for each dwelling unit on the property. Like floor area ratio, controls a property's density. " data-original-title='Lot area per unit' data-placement='top' rel='popover'>Lot area per unit</th>
+          <th data-content="The minimum size a lot has to be to build on it (for single-family zones, this is the same as 'lot area per unit')" data-original-title='Minimum lot area' data-placement='top' rel='popover'>Minimum lot area</th>
+          <th data-content="The amount of area required for each dwelling unit on the property. Like floor area ratio, controls a property's density. " data-original-title='Lot area per unit' data-placement='top' rel='popover'>Lot area per unit</th>
           <th data-content="How tall your building can be. While a building's FAR and Lot Area per Unit regulate its density, max building height works in concert with setback requirements to control its bulk." data-original-title='Maximum height' data-placement='top' rel='popover'>Maximum height</th>
           <th data-content="The required distance between a building and its lot's street-facing edge. Basically, how big your front yard needs to be. Controls a building's bulk." data-original-title='Front yard setback' data-placement='top' rel='popover'>Front yard setback</th>
           <th data-content="The required distance between a building and its lot's side property line. Basically, how much room you need to leave between buildings. Controls a building's bulk." data-original-title='Side yard setback' data-placement='top' rel='popover'>Side yard setback</th>
@@ -96,6 +97,7 @@ title: Zoning districts
             </a>
           </td>
           <td>0.5</td>
+          <td>6250</td>
           <td>6250</td>
           <td>30 ft for detached house. None for schools and churches.</td>
           <td>20ft, or 16% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
@@ -114,6 +116,7 @@ title: Zoning districts
           </td>
           <td>0.65</td>
           <td>5000</td>
+          <td>5000</td>
           <td>30 ft for detached house. None for schools and churches.</td>
           <td>20ft, or 16% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
           <td>
@@ -130,6 +133,7 @@ title: Zoning districts
             </a>
           </td>
           <td>0.9</td>
+          <td>2500</td>
           <td>2500</td>
           <td>30 ft for detached house. None for schools and churches.</td>
           <td>20ft, or 16% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
@@ -153,6 +157,7 @@ title: Zoning districts
           <th></th>
           <th>Name</th>
           <th data-content="A building's total floor area - that is, the square footage of every floor - divided by the area of the parcel of land it's built on. Controls a property's density." data-original-title='Floor area ratio' data-placement='top' rel='popover'>Floor area ratio</th>
+          <th data-content="The minimum size a lot has to be to build on it" data-original-title='Minimum lot area' data-placement='top' rel='popover'>Minimum lot area</th>
           <th data-content="The amount of lot area required for each dwelling unit on the property. Like floor area ratio, controls a property's density. " data-original-title='Lot area per unit' data-placement='top' rel='popover'>Lot area per unit</th>
           <th data-content="How tall your building can be. While a building's FAR and Lot Area per Unit regulate its density, max building height works in concert with setback requirements to control its bulk." data-original-title='Maximum height' data-placement='top' rel='popover'>Maximum height</th>
           <th data-content="The required distance between a building and its lot's street-facing edge. Basically, how big your front yard needs to be. Controls a building's bulk." data-original-title='Front yard setback' data-placement='top' rel='popover'>Front yard setback</th>
@@ -169,6 +174,7 @@ title: Zoning districts
             </a>
           </td>
           <td>1.05</td>
+          <td>2500</td>
           <td>1250</td>
           <td>35 ft for detached house. None for schools and churches.</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
@@ -183,6 +189,7 @@ title: Zoning districts
             </a>
           </td>
           <td>1.2</td>
+          <td>1650</td>
           <td>1000 sq ft/dwelling unit, 1000 sq ft/efficiency unit, 500 sq ft/SRO unit</td>
           <td>38 ft for detached house. None for schools and churches.</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
@@ -197,6 +204,7 @@ title: Zoning districts
             </a>
           </td>
           <td>1.2. 1.5 for buildings containing less than 20 dwelling units, where at least 33% of these are "accessible."</td>
+          <td>1650</td>
           <td>1000 sq ft/dwelling unit, 1000 sq ft/efficiency unit, 500 sq ft/SRO unit</td>
           <td>42 ft for buildings with less than 20 dwelling units, where at least 33% of these are "accessible." None for schools and churches.</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
@@ -217,6 +225,7 @@ title: Zoning districts
           <th></th>
           <th>Name</th>
           <th data-content="A building's total floor area - that is, the square footage of every floor - divided by the area of the parcel of land it's built on. Controls a property's density." data-original-title='Floor area ratio' data-placement='top' rel='popover'>Floor area ratio</th>
+          <th data-content="The minimum size a lot has to be to build on it" data-original-title='Minimum lot area' data-placement='top' rel='popover'>Minimum lot area</th>
           <th data-content="The amount of lot area required for each dwelling unit on the property. Like floor area ratio, controls a property's density. " data-original-title='Lot area per unit' data-placement='top' rel='popover'>Lot area per unit</th>
           <th data-content="How tall your building can be. While a building's FAR and Lot Area per Unit regulate its density, max building height works in concert with setback requirements to control its bulk." data-original-title='Maximum height' data-placement='top' rel='popover'>Maximum height</th>
           <th data-content="The required distance between a building and its lot's street-facing edge. Basically, how big your front yard needs to be. Controls a building's bulk." data-original-title='Front yard setback' data-placement='top' rel='popover'>Front yard setback</th>
@@ -234,6 +243,7 @@ title: Zoning districts
           </td>
           <td>1.7</td>
           <td>700 sq ft/dwelling unit, 700 sq ft/efficiency unit, 500 sq ft/SRO unit</td>
+          <td>1650</td>
           <td>45 ft for residential buildings with lot frontage of less than 32 ft, 47 ft when lot front is over that. None for schools and churches.</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
           <td>Townhouses: complicated as hell, see 17-2-0500. All other buildings: Combined width of side setbacks must equal 20% of lot width, and neither setback can be less than 2 feet or 8% of lot width (whichever is greater.) But no setback is required to be wider than 5 feet.</td>
@@ -248,6 +258,7 @@ title: Zoning districts
           </td>
           <td>2</td>
           <td>400 sq ft/dwelling unit, 400 sq ft/efficiency unit, 200 sq ft/SRO unit</td>
+          <td>1650</td>
           <td>45 ft for residential buildings with lot frontage of less than 32 ft, 47 ft when lot front is over that. None for schools and churches.</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
           <td>Townhouses: complicated as hell, see 17-2-0500. All other buildings: Combined width of side setbacks must equal 20% of lot width, and neither setback can be less than 2 feet or 8% of lot width (whichever is greater.) But no setback is required to be wider than 5 feet.</td>
@@ -262,6 +273,7 @@ title: Zoning districts
           </td>
           <td>2.5</td>
           <td>400 sq ft/dwelling unit, 400 sq ft/efficiency unit, 200 sq ft/SRO unit</td>
+          <td>1650</td>
           <td>47 ft for residential buildings with lot frontage of less than 75 ft, 60 ft when lot front is over that. None for schools and churches.</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
           <td>Townhouses: complicated as hell, see 17-2-0500. All other buildings: Combined width of side setbacks must equal 20% of lot width, and neither setback can be less than 2 feet or 8% of lot width (whichever is greater.) But no setback is required to be wider than 5 feet.</td>
@@ -276,6 +288,7 @@ title: Zoning districts
           </td>
           <td>4.4</td>
           <td>300 sq ft/dwelling unit, 135 sq ft/efficiency unit, 135 sq ft/SRO unit</td>
+          <td>1650</td>
           <td>None, but tall buildings require planned development approval (see Sec. 17-13-0600).</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>
           <td>Townhouses: complicated as hell, see 17-2-0500. All other buildings: none if building abuts the street or alley, or if building covers less than 50% of its lot. If more than 50%, building's side setbacks must equal 10% of lot width or 10% of building height (whichever is greater), but no setback needs to be wider than 20 ft.</td>
@@ -289,6 +302,7 @@ title: Zoning districts
             </a>
           </td>
           <td>6.6</td>
+          <td>1650</td>
           <td>300 sq ft/dwelling unit, 135 sq ft/efficiency unit, 135 sq ft/SRO unit</td>
           <td>None, but tall buildings require planned development approval (see Sec. 17-13-0600).</td>
           <td>15ft, or 12% of lot depth, whichever is less. Alternatively, setback can be the average front yard depth of nearest 2 lots.</td>


### PR DESCRIPTION
Adds a new column to residential tables about minimum lot area. This is the minimum size a lot has to be in order to build an allowable building in that zone. This is important for multi-unit districts (anything that starts with an R that's not RS).