### PR TITLE
Fixed City of Chicago Zoning Ordinance link.

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -93,7 +93,7 @@ description: "2nd City Zoning is an interactive map that lets you find out how y
     </p>
     <p>
       It consists of
-      <a href='http://library.amlegal.com/nxt/gateway.dll/Illinois/chicagozoning/chicagozoningordinanceandlanduseordinanc?f=templates$fn=default.htm$3.0$vid=amlegal:chicagozoning_il'>regulations</a>
+      <a href='https://codelibrary.amlegal.com/codes/chicago/latest/chicagozoning_il/0-0-0-48006'>regulations</a>
       that control how big of a building you can build on a property,
       what you can do inside it. You can't just build anything anywhere -
       every property in Chicago lives in a zoning district of one kind or another.
@@ -204,7 +204,7 @@ description: "2nd City Zoning is an interactive map that lets you find out how y
       below. To learn more about a particular district, visit the
       <a href='/zones'>zoning districts page</a>
       or read the
-      <a href='http://library.amlegal.com/nxt/gateway.dll/Illinois/chicagozoning/chicagozoningordinanceandlanduseordinanc?f=templates$fn=default.htm$3.0$vid=amlegal:chicagozoning_il'>City of Chicago Zoning Ordinance</a>.
+      <a href='https://codelibrary.amlegal.com/codes/chicago/latest/chicagozoning_il/0-0-0-48006'>City of Chicago Zoning Ordinance</a>.
     </p>
     <h5>
       <a href='/zones#R'>

--- a/zones/index.html
+++ b/zones/index.html
@@ -15,7 +15,7 @@ description: "Zoning basically makes sure a factory doesn't open next to a schoo
         </p>
         <p>
           It consists of
-          <a href='http://library.amlegal.com/nxt/gateway.dll/Illinois/chicagozoning/chicagozoningordinanceandlanduseordinanc?f=templates$fn=default.htm$3.0$vid=amlegal:chicagozoning_il'>regulations</a>
+          <a href='http://library.amlegal.com/nxt/gateway.dll/Illinois/chicagozoning/chicagozoningordinanceandlanduseordinanc?f=templates$fn=default.htm$3.0$vid=amlegal:chicagozoning_ilhttps://codelibrary.amlegal.com/codes/chicago/latest/chicagozoning_il/0-0-0-48006'>regulations</a>
           that control how big of a building you can build on a property,
           what you can do inside it. You can't just build anything anywhere -
           every property in Chicago lives in a zoning district of one kind or another.

--- a/zones/index.html
+++ b/zones/index.html
@@ -15,7 +15,7 @@ description: "Zoning basically makes sure a factory doesn't open next to a schoo
         </p>
         <p>
           It consists of
-          <a href='http://library.amlegal.com/nxt/gateway.dll/Illinois/chicagozoning/chicagozoningordinanceandlanduseordinanc?f=templates$fn=default.htm$3.0$vid=amlegal:chicagozoning_ilhttps://codelibrary.amlegal.com/codes/chicago/latest/chicagozoning_il/0-0-0-48006'>regulations</a>
+          <a href='https://codelibrary.amlegal.com/codes/chicago/latest/chicagozoning_il/0-0-0-48006'>regulations</a>
           that control how big of a building you can build on a property,
           what you can do inside it. You can't just build anything anywhere -
           every property in Chicago lives in a zoning district of one kind or another.

--- a/zoning_rules/index.html
+++ b/zoning_rules/index.html
@@ -49,7 +49,7 @@ description: "Zoning is about land use (what you can do with a property) and den
       zoning ordinance:
     </p>
 
-    <p><a class='btn btn-danger' href='http://library.amlegal.com/nxt/gateway.dll/Illinois/chicagozoning/chicagozoningordinanceandlanduseordinanc?f=templates$fn=default.htm$3.0$vid=amlegal:chicagozoning_il'><i class='fa fa-fw fa-file-text'></i> City of Chicago Zoning Ordinance</a></p>
+    <p><a class='btn btn-danger' href='https://codelibrary.amlegal.com/codes/chicago/latest/chicagozoning_il/0-0-0-48006'><i class='fa fa-fw fa-file-text'></i> City of Chicago Zoning Ordinance</a></p>
 
     <p>
       Each zoning district has rules ("bulk and density requirements," in zoning-speak) that restrict the density of buildings you can build on properties within the district. These


### PR DESCRIPTION
Currently, the link just re-routes to American Legal Publishing main index. I'm not 100% sure this was the destination of the original link, but it seems like it.

Thanks!