### PR TITLE
updated data from oct 21 2024

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@ layout: default
   <div class='col-md-8'>
     <div id='mapCanvas'></div>
     <span class='pull-right'>
-      Data accurate as of Oct 25, 2023. By <a class='yay-link' href='https://datamade.us'>DataMade</a>, <a class='yay-link' href='http://derekeder.com'>Derek Eder</a>, and <a href='https://jpvelez.contently.com'>Juan-Pablo Velez</a><a class='simcopter' href='#'>.</a>
+      Data accurate as of Oct 21, 2024. By <a class='yay-link' href='https://datamade.us'>DataMade</a>, <a class='yay-link' href='http://derekeder.com'>Derek Eder</a>, and <a href='https://jpvelez.contently.com'>Juan-Pablo Velez</a><a class='simcopter' href='#'>.</a>
     </span>
   </div>
 </div>

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -6,8 +6,7 @@ var CartoDbLib = {
   lastClickedLayer: null,
   locationScope:   "chicago",
   currentPinpoint: null,
-  layerUrl: 'https://datamade.carto.com/api/v2/viz/eb3d95da-4490-42e8-9f80-ed43b3f82cd6/viz.json',
-  tableName: 'second_city_zoning_2023_10_25',
+  tableName: 'second_city_zoning_2024_10_21',
 
   initialize: function(){
 


### PR DESCRIPTION
Pulls latest zoning shape data from City ArcGIS server following the steps from https://github.com/datamade/second-city-zoning/issues/18

Steps:

1. Setup & install [pyesridump](https://github.com/datamade/pyesridump)
2. run `esri2geojson http://gisapps.cityofchicago.org/arcgis/rest/services/ExternalApps/Zoning/MapServer/1 chicago-zoning.geojson`
3. upload GeoJSON file to CARTO
4. copy CartoCSS from previous data
5. update the table references and updated date on `js/cartodb_lib.js` and `index.html`